### PR TITLE
refactor: replace type assertions in pageStore & pageCart

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -53,24 +53,27 @@
     </div>
   </div>
 
-  <div class="item_template invisible">
-    <h4 class="item_name"></h4>
-    <div class="item_pic">
-      <img class="item_pic_img">
+  <template class="item_template">
+    <div class="store_item">
+      <h4 class="item_name"></h4>
+      <div class="item_pic">
+        <img class="item_pic_img">
+      </div>
+      <div class="item_parameters">
+        <span class="item_category"></span>
+        <span class="item_subcategory"></span>
+        <span class="item_brand"></span>
+        <span class="item_count"></span>
+        <span class="item_amount"></span>
+        <span class="item_age"></span>
+      </div>
+      <div class="item_price"></div>
+      <button class="add_item_to_cart">Add to cart</button>
     </div>
-    <div class="item_parameters">
-      <span class="item_category"></span>
-      <span class="item_subcategory"></span>
-      <span class="item_brand"></span>
-      <span class="item_count"></span>
-      <span class="item_amount"></span>
-      <span class="item_age"></span>
-    </div>
-    <div class="item_price"></div>
-    <button class="add_item_to_cart">Add to cart</button>
-  </div>
+  </template>
 
-  <div class="cart_item_template invisible">
+<template class="cart_item_template">
+  <div class="cart_item">
     <h4 class="cart_item_name"></h4>
     <div class="cart_item_pic">
       <img class="cart_item_pic_img">
@@ -85,11 +88,13 @@
     </div>
     <div class="cart_item_price"></div>
     <div class="cart_item_amount">
-      <div class="cart_item_amount_less">-</div> 
+      <div class="cart_item_amount_less">-</div>
       <div class="cart_item_amount">current</div>
       <div class="cart_item_amount_more">+</div>
     </div>
   </div>
+
+</template>
 
 </body>
 

--- a/src/modules/controller/gallery.ts
+++ b/src/modules/controller/gallery.ts
@@ -1,12 +1,26 @@
 import Product from './product';
 
-const gallery = function () {
-  const galleryArr = new Set();
-  for (let i = 0; i < 30; i++) {
-    const item = new Product(i);
-    galleryArr.add(item);
-  }
-  return galleryArr;
-};
+class Gallery {
+  static items: Array<Product> = [];
 
-export default gallery;
+  static getUniqueItems() {
+    for (let i = 0; i < 30; i++) {
+      const item = new Product(i);
+      this.items.push(item);
+    }
+    return this.items;
+  }
+}
+
+// const gallery = function () {
+//   const galleryArr = new Set();
+//   for (let i = 0; i < 30; i++) {
+//     const item = new Product(i);
+//     galleryArr.add(item);
+//   }
+//   return galleryArr;
+// };
+
+// export default gallery;
+
+export default Gallery;

--- a/src/modules/view/pages/pageCart.ts
+++ b/src/modules/view/pages/pageCart.ts
@@ -1,5 +1,6 @@
 import Cart from '../../controller/cart';
 import Page from '../templates/pageTemplate';
+import Product from '../../controller/product';
 
 class CartPage extends Page {
   static textObj = {
@@ -44,40 +45,72 @@ class CartPage extends Page {
   }
 
   drawCardCart() {
-    const items = Cart.getUniqueItems();
+    const items: Product[] = Cart.getUniqueItems();
 
-    const fragment = document.createDocumentFragment();
-    const template = document.querySelector('.cart_item_template') as HTMLTemplateElement;
+    const fragment: DocumentFragment = document.createDocumentFragment();
+    const template: HTMLTemplateElement | null = document.querySelector('.cart_item_template') as HTMLTemplateElement;
     // const cardBlock = document.querySelector('.cart_items_body') as HTMLElement;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    items.forEach((item: any) => {
-      const itemClone = template.cloneNode(true) as HTMLTemplateElement;
-      itemClone.classList.remove('invisible');
-      const itemName = itemClone.querySelector('.cart_item_name') as HTMLElement;
-      const itemPicture = itemClone.querySelector('.cart_item_pic_img') as HTMLImageElement;
-      const itemCategory = itemClone.querySelector('.cart_item_category') as HTMLElement;
-      const itemSubCategory = itemClone.querySelector('.item_subcategory') as HTMLElement;
-      const itemBrand = itemClone.querySelector('.item_brand') as HTMLElement;
-      const itemCount = itemClone.querySelector('.item_count') as HTMLElement;
-      const itemAmount = itemClone.querySelector('.item_amount') as HTMLElement;
-      const itemAge = itemClone.querySelector('.item_age') as HTMLElement;
-      const itemPrice = itemClone.querySelector('.cart_item_price') as HTMLElement;
-      // const addBtn = itemClone.querySelector('.cart_item_amount_less') as HTMLElement;
+    if (template) {
+      items.forEach((item: Product) => {
+        const itemClone: DocumentFragment | Node = template.content.cloneNode(true);
+        if (itemClone instanceof DocumentFragment && itemClone) {
+          // itemClone.classList.remove('invisible');
 
-      itemName.textContent = `Name: ${item.title}`;
-      itemPicture.src = item.thumbnail;
-      itemCategory.textContent = `Category: ${item.theme}`;
-      itemSubCategory.textContent = `SubCategory: ${item.interests}`;
-      itemBrand.textContent = `Brand: LEGO`;
-      itemCount.textContent = `Count: ${item.detailsCount}`;
-      itemAmount.textContent = `Amount: ${item.stock}`;
-      itemAge.textContent = `Age: ${item.minAge} to ${item.maxAge}`;
-      itemPrice.textContent = `Price: ${item.priceByn} BYN`;
-      fragment.append(itemClone);
-      // addBtn.addEventListener('click', () => Cart.addItem(item.id));
-    });
+          const itemName: HTMLElement | null = itemClone.querySelector('.cart_item_name');
+          if (itemName) {
+            itemName.textContent = `Name: ${item.title}`;
+          }
 
+          const itemPicture: HTMLImageElement | null = itemClone.querySelector('.cart_item_pic_img');
+          if (itemPicture) {
+            itemPicture.src = item.thumbnail;
+          }
+
+          const itemCategory: HTMLElement | null = itemClone.querySelector('.cart_item_category');
+          if (itemCategory) {
+            itemCategory.textContent = `Category: ${item.theme}`;
+          }
+
+          const itemSubCategory: HTMLElement | null = itemClone.querySelector('.item_subcategory');
+          if (itemSubCategory) {
+            itemSubCategory.textContent = `SubCategory: ${item.interests}`;
+          }
+
+          const itemBrand: HTMLElement | null = itemClone.querySelector('.item_brand');
+          if (itemBrand) {
+            itemBrand.textContent = `Brand: LEGO`;
+          }
+
+          const itemCount: HTMLElement | null = itemClone.querySelector('.item_count');
+          if (itemCount) {
+            itemCount.textContent = `Count: ${item.detailsCount}`;
+          }
+
+          const itemAmount: HTMLElement | null = itemClone.querySelector('.item_amount');
+          if (itemAmount) {
+            itemAmount.textContent = `Amount: ${item.stock}`;
+          }
+
+          const itemAge: HTMLElement | null = itemClone.querySelector('.item_age');
+          if (itemAge) {
+            itemAge.textContent = `Age: ${item.minAge} to ${item.maxAge}`;
+          }
+
+          const itemPrice: HTMLElement | null = itemClone.querySelector('.cart_item_price');
+          if (itemPrice) {
+            itemPrice.textContent = `Price: ${item.priceByn} BYN`;
+          }
+
+          // const addBtn: HTMLButtonElement | null = itemClone.querySelector('.cart_item_amount_less');
+          // if (addBtn) {
+          //   addBtn.addEventListener('click', () => Cart.addItem(item));
+          //   // addBtn.addEventListener('click', () => Cart.addItem(item.id));
+          // }
+          fragment.append(itemClone);
+        }
+      });
+    }
     // cardBlock.innerHTML = '';
     // cardBlock.appendChild(fragment);
     this.container.append(fragment);

--- a/src/modules/view/pages/pageStore.ts
+++ b/src/modules/view/pages/pageStore.ts
@@ -1,6 +1,8 @@
 import Cart from '../../controller/cart';
-import gallery from '../../controller/gallery';
+// import gallery from '../../controller/gallery';
+import Gallery from '../../controller/gallery';
 import Page from '../templates/pageTemplate';
+import Product from '../../controller/product';
 
 class StorePage extends Page {
   static textObj = {
@@ -97,42 +99,87 @@ class StorePage extends Page {
   }
 
   drawCardStore() {
-    const items = gallery();
-    const fragment = document.createDocumentFragment();
-    const productCardTemplate = document.querySelector('.item_template') as HTMLTemplateElement;
+    const items: Product[] = Gallery.getUniqueItems();
+    // const items = gallery();
+    const fragment: DocumentFragment = document.createDocumentFragment();
+    const productCardTemplate: HTMLTemplateElement | null = document.querySelector('.item_template');
     // const cardBlock = document.querySelector('.gallery_wrapper') as HTMLElement;
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    items.forEach((item: any) => {
-      const itemClone = productCardTemplate.cloneNode(true) as HTMLTemplateElement;
-      itemClone.classList.remove('invisible');
-      const itemName = itemClone.querySelector('.item_name') as HTMLElement;
-      const itemPicture = itemClone.querySelector('.item_pic_img') as HTMLImageElement;
-      const itemCategory = itemClone.querySelector('.item_category') as HTMLElement;
-      const itemSubCategory = itemClone.querySelector('.item_subcategory') as HTMLElement;
-      const itemBrand = itemClone.querySelector('.item_brand') as HTMLElement;
-      const itemCount = itemClone.querySelector('.item_count') as HTMLElement;
-      const itemAmount = itemClone.querySelector('.item_amount') as HTMLElement;
-      const itemAge = itemClone.querySelector('.item_age') as HTMLElement;
-      const itemPrice = itemClone.querySelector('.item_price') as HTMLElement;
-      const addBtn = itemClone.querySelector('.add_item_to_cart') as HTMLElement;
+    if (productCardTemplate) {
+      items.forEach((item: Product) => {
+        const itemClone: DocumentFragment | Node = productCardTemplate.content.cloneNode(true);
+        if (itemClone instanceof DocumentFragment && itemClone) {
+          // itemClone.classList.remove('invisible');
 
-      itemName.textContent = `Name: ${item.title}`;
-      itemPicture.src = item.thumbnail;
-      itemCategory.textContent = `Category: ${item.theme}`;
-      itemSubCategory.textContent = `SubCategory: ${item.interests}`;
-      itemBrand.textContent = `Brand: LEGO`;
-      itemCount.textContent = `Count: ${item.detailsCount}`;
-      itemAmount.textContent = `Amount: ${item.stock}`;
-      itemAge.textContent = `Age: ${item.minAge} to ${item.maxAge}`;
-      itemPrice.textContent = `Price: ${item.priceByn} BYN`;
-      fragment.append(itemClone);
-      addBtn.addEventListener('click', () => Cart.addItem(item));
-    });
+          const itemName: HTMLElement | null = itemClone.querySelector('.item_name');
+          if (itemName) {
+            itemName.textContent = `Name: ${item.title}`;
+          }
+
+          const itemPicture: HTMLImageElement | null = itemClone.querySelector('.item_pic_img');
+          if (itemPicture) {
+            itemPicture.src = item.thumbnail;
+          }
+
+          const itemCategory: HTMLElement | null = itemClone.querySelector('.item_category');
+          if (itemCategory) {
+            itemCategory.textContent = `Category: ${item.theme}`;
+          }
+
+          const itemSubCategory: HTMLElement | null = itemClone.querySelector('.item_subcategory');
+          if (itemSubCategory) {
+            itemSubCategory.textContent = `SubCategory: ${item.interests}`;
+          }
+
+          const itemBrand: HTMLElement | null = itemClone.querySelector('.item_brand');
+          if (itemBrand) {
+            itemBrand.textContent = `Brand: LEGO`;
+          }
+
+          const itemCount: HTMLElement | null = itemClone.querySelector('.item_count');
+          if (itemCount) {
+            itemCount.textContent = `Count: ${item.detailsCount}`;
+          }
+
+          const itemAmount: HTMLElement | null = itemClone.querySelector('.item_amount');
+          if (itemAmount) {
+            itemAmount.textContent = `Amount: ${item.stock}`;
+          }
+
+          const itemAge: HTMLElement | null = itemClone.querySelector('.item_age');
+          if (itemAge) {
+            itemAge.textContent = `Age: ${item.minAge} to ${item.maxAge}`;
+          }
+
+          const itemPrice: HTMLElement | null = itemClone.querySelector('.item_price');
+          if (itemPrice) {
+            itemPrice.textContent = `Price: ${item.priceByn} BYN`;
+          }
+          const addBtn: HTMLButtonElement | null = itemClone.querySelector('.add_item_to_cart');
+
+          // const addBtn = itemClone.querySelector('.add_item_to_cart') as HTMLElement;
+          // fragment.append(itemClone);
+          if (addBtn) {
+            addBtn.addEventListener('click', () => Cart.addItem(item));
+          }
+          fragment.append(itemClone);
+          console.log('append');
+        }
+      });
+    }
 
     // cardBlock.innerHTML = '';
     // cardBlock.appendChild(fragment);
+
+    // const galleryWrap: HTMLElement | null = document.querySelector('.gallery_wrapper');
+    // console.log('gellery wrap', galleryWrap);
+    // if (galleryWrap) {
+    //   console.log('gellery wrap');
+    //   galleryWrap.append(fragment);
+    // }
+
     this.container.append(fragment);
+    console.log(this.container); //div current-page
   }
 
   render() {

--- a/src/style/_default.scss
+++ b/src/style/_default.scss
@@ -43,7 +43,7 @@ h1, h2, h3, h4, h5, h6, p {
 
 .wrapper {
   width: 100%;
-  max-width: 1200px; 
+  max-width: 1200px;
   margin: 0 auto;
 }
 
@@ -70,7 +70,7 @@ h1, h2, h3, h4, h5, h6, p {
   width: 100px;
 }
 
-.item_template, .cart_item_template {
+.store_item, .cart_item {
   width: 200px;
   border: 1px solid #000;
   border-radius: 10px;


### PR DESCRIPTION
1) pageCart.ts & pageStore.ts - заменила 'as' типизацией и проверками на null
2) gallery.ts - переписала из функции в Класс (нужно было для типизации pageStore)
3) index.html - для store-item & cart-item templates поставила тег `template`
----------------------
TODO:
сейчас в Галерее и в Корзине айтемы аппендятся просто в конец current page - а нужно, чтобы они добавлялись в Корзине в `<div class="cart_items_body">`, а в Галерее в `<div class="gallery_wrapper">`

![image](https://user-images.githubusercontent.com/99749026/209217585-9dd86861-bfb8-4937-880b-b1c2772cd793.png)
