### PR TITLE
feat: add product page image switch and appearance

### DIFF
--- a/src/modules/controller/gallery.ts
+++ b/src/modules/controller/gallery.ts
@@ -33,9 +33,11 @@ class Gallery {
       for (const [key, value] of Object.entries(filtersUsedObj)) {
         // console.log(key, value);
         if (Array.isArray(value) && value.length !== 0) {
+          // Gallery.queryStr += `&${key}=${value}`;
           Gallery.queryStr += `/${key}=${value.join(',')}`;
+
           // for (let i = 0; i < value.length; i++) {
-          //   Gallery.queryStr += `${value[i]},`;
+          //   Gallery.queryStr += `&${key}=${value[i]}`;
           // }
         }
       }

--- a/src/modules/view/appView.ts
+++ b/src/modules/view/appView.ts
@@ -68,6 +68,10 @@ class AppView {
     }
 
     if (page instanceof ProductPage) {
+      const pageWrap = document.querySelector('#current-page');
+      if (pageWrap) {
+        pageWrap.classList.add('product_page');
+      }
       const id = +pageID.slice(13);
       const product = Cart.getProduct(id);
       page.render(product);

--- a/src/modules/view/pages/pageProduct.ts
+++ b/src/modules/view/pages/pageProduct.ts
@@ -1,6 +1,5 @@
 import Cart from '../../controller/cart';
 import openModal from '../../controller/modal/openModal';
-// import Product from '../../controller/product';
 import Page from '../templates/pageTemplate';
 import { IProduct } from '../../types/types';
 import changeBtn from '../../controller/addInCart';
@@ -14,7 +13,7 @@ class ProductPage extends Page {
     super(id);
   }
 
-  breadcrumbs(item?: IProduct) {
+  private breadcrumbs(item?: IProduct): void {
     if (item) {
       const store = document.createElement('a');
       store.href = '#main-page';
@@ -45,7 +44,16 @@ class ProductPage extends Page {
     }
   }
 
-  renderButtons(item?: IProduct) {
+  private changePicture(event: Event, mainPicture: HTMLImageElement, item: IProduct, images: HTMLCollection): void {
+    if (event.target instanceof HTMLImageElement) {
+      Array.from(images).forEach((image) => image.classList.remove('selected'));
+      event.target.classList.add('selected');
+      const id: number = +event.target.id;
+      mainPicture.src = `${item.images[id]}`;
+    }
+  }
+
+  private renderButtons(item?: IProduct): void {
     if (item) {
       const addBtn = document.createElement('button');
       if (Cart.getProductAmount(item.id)) {
@@ -64,6 +72,7 @@ class ProductPage extends Page {
       buyBtn.addEventListener('click', () => openModal());
 
       const buttons = document.createElement('div');
+      buttons.classList.add('buttons_wrapper');
       buttons.append(addBtn);
       buttons.append(buyBtn);
 
@@ -71,7 +80,7 @@ class ProductPage extends Page {
     }
   }
 
-  renderProduct(item?: IProduct) {
+  private renderProduct(item?: IProduct): void {
     const product = document.createElement('div');
     if (item) {
       const title = document.createElement('h3');
@@ -88,47 +97,82 @@ class ProductPage extends Page {
       for (let i = 0; i < item.images.length; i++) {
         const picture = document.createElement('img');
         picture.classList.add('item_additional_picture');
+        if (i === 0) {
+          picture.classList.add('selected');
+        }
+        picture.setAttribute('id', `${i}`);
         picture.src = `${item.images[i]}`;
         additionalPicture.append(picture);
       }
 
+      const brand = document.createElement('div');
+      brand.classList.add('item_characteristic');
+      brand.innerText = `Brand: `;
+      const brandDesc = document.createElement('span');
+      brandDesc.innerText = `LEGO`;
+      brand.append(brandDesc);
+
       const category = document.createElement('div');
       category.classList.add('item_characteristic');
-      category.innerText = `Category: ${item.theme}`;
+      category.innerText = `Category: `;
+      const categoryDesc = document.createElement('span');
+      categoryDesc.innerText = `${item.theme}`;
+      category.append(categoryDesc);
 
       const interests = document.createElement('div');
       interests.classList.add('item_characteristic');
-      interests.innerText = `Interests: ${item.interests}`;
+      interests.innerText = `Interests: `;
+      const interestsDesc = document.createElement('span');
+      interestsDesc.innerText = `${item.interests}`;
+      interests.append(interestsDesc);
 
-      const brand = document.createElement('div');
-      brand.classList.add('item_characteristic');
-      brand.innerText = `Brand: LEGO`;
+      const code = document.createElement('div');
+      code.classList.add('item_characteristic');
+      code.innerText = `Product code: `;
+      const codeDesc = document.createElement('span');
+      codeDesc.innerText = `${item.key}`;
+      code.append(codeDesc);
 
       const count = document.createElement('div');
       count.classList.add('item_characteristic');
-      count.innerText = `Pieces: ${item.detailsCount}`;
+      count.innerText = `Pieces: `;
+      const countDesc = document.createElement('span');
+      countDesc.innerText = `${item.detailsCount}`;
+      count.append(countDesc);
 
-      const amount = document.createElement('div');
-      amount.classList.add('item_characteristic');
-      amount.innerText = `Amount: ${item.stock}`;
+      const stock = document.createElement('div');
+      stock.classList.add('item_characteristic');
+      stock.innerText = `Stock: `;
+      const stockDesc = document.createElement('span');
+      stockDesc.innerText = `${item.stock}`;
+      stock.append(stockDesc);
 
       const age = document.createElement('div');
       age.classList.add('item_characteristic');
-      age.innerText = `Age: ${item.minAge} to ${item.maxAge}`;
+      age.innerText = `Age: `;
+      const ageDesc = document.createElement('span');
+      ageDesc.innerText = `${item.age.minAge} to ${item.age.maxAge}`;
+      age.append(ageDesc);
 
       const description = document.createElement('div');
       description.classList.add('item_characteristic');
-      description.innerText = `Description: ${item.description}`;
+      description.innerText = `Description: `;
+      const descriptionDesc = document.createElement('span');
+      descriptionDesc.innerText = `${item.description}`;
+      description.append(descriptionDesc);
 
       const parameters = document.createElement('div');
       parameters.classList.add('item_parameters');
-      parameters.append(category);
-      parameters.append(interests);
-      parameters.append(brand);
-      parameters.append(count);
-      parameters.append(amount);
-      parameters.append(age);
+      const detailsWrap = document.createElement('div');
+      detailsWrap.classList.add('details_wrapper');
       parameters.append(description);
+      parameters.append(detailsWrap);
+      detailsWrap.append(category);
+      detailsWrap.append(interests);
+      detailsWrap.append(code);
+      detailsWrap.append(count);
+      detailsWrap.append(stock);
+      detailsWrap.append(age);
 
       const price = document.createElement('h4');
       price.classList.add('item_price');
@@ -136,39 +180,24 @@ class ProductPage extends Page {
 
       const wrapper = document.createElement('div');
       wrapper.classList.add('item_wrapper');
+
       wrapper.append(title);
       wrapper.append(mainPicture);
       wrapper.append(additionalPicture);
       wrapper.append(parameters);
       wrapper.append(price);
-
       product.append(wrapper);
 
-      // product.innerHTML = `
-      //     <div class="item_page">
-      //       <div class="card_wrapper">
-      //         <h4 class="item_name">Item name: ${item.title}</h4>
-      //         <div class="item_pic">
-      //           <img class="ilem_pic_img" src="${item.thumbnail}">
-      //         </div>
-      //         <div class="item_parameters">
-      //           <div class="item_category">Category: ${item.theme}</div>
-      //           <div class="item_subcategory">SubCategory: ${item.interests}</div>
-      //           <div class="item_brand">Brand: LEGO</div>
-      //           <div class="item_count">Count: ${item.detailsCount}</div>
-      //           <div class="item_subcategory">Amount: ${item.stock}</div>
-      //           <div class="item_brand">Age: ${item.minAge} to ${item.maxAge}</div>
-      //           <p class="irem_description">Description: ${item.description} </p>
-      //         </div>
-      //         <div class="item_price">Price: ${item.priceByn} BYN</div>
-      //       </div>
-      //     </div>`;
+      additionalPicture.addEventListener('click', (event) => {
+        const images = additionalPicture.children;
+        this.changePicture(event, mainPicture, item, images);
+      });
     }
 
     this.container.append(product);
   }
 
-  render(item?: IProduct) {
+  public render(item?: IProduct): HTMLElement {
     this.breadcrumbs(item);
     this.renderProduct(item);
     this.renderButtons(item);

--- a/src/style/_product_page.scss
+++ b/src/style/_product_page.scss
@@ -1,7 +1,114 @@
-.item_main_picture {
-    width: 300px;
+.product_page {
+  margin: 24px 0;
+  padding: 0 24px;
+
+  & .item_name {
+    grid-column-start: 1;
+    grid-row-start: 1;
+  }
+
+  & .item_main_picture {
+    grid-column-start: 1;
+    grid-row-start: 2;
+    margin: 0 auto;
+    padding: 16px;
+    width: auto;
+    height: 100%;
+  }
+
+  & .pictures_wrapper {
+    display: flex;
+    justify-content: center;
+    gap: 24px;
+    grid-column-start: 1;
+    grid-row-start: 3;
+    // margin-top: 16px;
+    width: 100%;
+  }
+
+  & .item_additional_picture {
+    align-self: center;
+    padding: 12px;
+    width: auto;
+    height: 100%;
+  }
+
+  & .item_additional_picture:hover {
+    cursor: pointer;
+    border: solid 2px orange;
+    border-radius: $border-radius-small;
+    transform: scale(1.02);
+    transition: transform ease-in-out 0.3s;
+  }
+
+  & .item_additional_picture.selected {
+    border: solid 2px orange;
+    border-radius: $border-radius-small;
+  }
+
+  & .item_additional_picture.selected:hover {
+    cursor: default;
+    transform: none;
+    transition: none;
+  }
+
+  & .item_parameters {
+    grid-column-start: 2;
+    grid-row-start: 2;
+    align-self: center;
+    display: flex;
+    flex-direction: column;
+    gap: 36px;
+  }
+
+  & .details_wrapper {
+    display: grid;
+    grid-template-columns: repeat(3, auto);
+    gap: 24px;
+  }
+
+  & .item_characteristic {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    font-weight: bold;
+
+    & span {
+      font-weight: 400;
+    }
+  }
+
+  & .item_price {
+    grid-column-start: 2;
+    grid-row-start: 3;
+    align-self: flex-end;
+    justify-self: flex-end;
+  }
+
+  & .buttons_wrapper {
+    display: flex;
+    justify-content: flex-end;
+    gap: 16px;
+  }
 }
 
-.item_additional_picture {
-    width: 100px;
+.breadcrumbs {
+  margin-bottom: 20px;
 }
+
+.item_wrapper {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  grid-template-rows: 28px 500px 100px;
+  column-gap: 24px;
+  row-gap: 8px;
+  margin-bottom: 16px;
+}
+
+// .item_main_picture {
+//   width: 300px;
+// }
+
+// .item_additional_picture {
+//   width: 100px;
+// }

--- a/src/style/_storepage.scss
+++ b/src/style/_storepage.scss
@@ -136,7 +136,7 @@
   color: #a5a1a1;
   background-color: transparent;
   border: 1px solid #E6E6E6;
-  border-radius: 8px;
+  border-radius: $border-radius-small;
 }
 
 .search_input:focus {
@@ -259,7 +259,7 @@
     width: 100%;
     text-align: center;
     border: 1px solid #c4c4c4;
-    border-radius: 10px;
+    border-radius: $border-radius;
   }
 
   & .item_info {
@@ -289,7 +289,7 @@
     width: 100%;
     text-align: left;
     border: 1px solid #c4c4c4;
-    border-radius: 10px;
+    border-radius: $border-radius;
   }
 
   & .item_info {
@@ -326,36 +326,6 @@
     grid-row-start: 3;
   }
 }
-
-// .store_item {
-//   display: flex;
-//   flex-direction: column;
-//   justify-content: space-between;
-//   gap: 8px;
-//   padding: 16px 12px;
-//   width: 100%;
-//   text-align: center;
-//   border: 1px solid #c4c4c4;
-//   border-radius: 10px;
-// }
-
-// .store_item:hover {
-//   cursor: pointer;
-//   transform: scale(1.02);
-//   transition: transform ease-in-out 0.3s;
-// }
-
-// .item_info {
-//   display: flex;
-//   flex-direction: column;
-//   justify-content: space-between;
-//   gap: 8px;
-//   height: 100%;
-// }
-
-// .item_pic_img {
-//   width: 132px;
-// }
 
 .item_parameters {
   display: flex;

--- a/src/style/_var.scss
+++ b/src/style/_var.scss
@@ -1,1 +1,3 @@
 //all variables values here
+$border-radius-small: 8px;
+$border-radius: 10px;


### PR DESCRIPTION
1) сделала переключение картинок по клику на странице product
2) добавила немного стилей на страницу product

TODO:
- оформить breadcrumbs (?? может ссылку оставить только на store? в демо в хлебных крошках кликабельно только store - там ведёт на главную со **сброшенными** фильтрами - у нас сейчас ведёт на главную с последним состоянием фильтров)
- _присутствует кнопка быстрой покупки товара. При клике, если товара нет в корзине, происходит автоматическое добавление в корзину и переход на страницу корзины, с уже открытым модальным окном. Если товар уже был в корзине, повторное добавление не требуется +5_ - **у нас просто модалка открывается на той же странице**
- _страница конкретного товара имеет свой маршрут. Например, страница с товаром [MacBook Pro](https://online-store-rs.netlify.app/product-details/6) открывается вне зависимости от того, посещались ли другие страницы приложения +10_

![image](https://user-images.githubusercontent.com/99749026/210653972-88b03254-f063-4117-9dcc-41498aa7cbba.png)
