### PR TITLE
feat: add separate routing for product page and cart page

### DIFF
--- a/src/modules/view/appView.ts
+++ b/src/modules/view/appView.ts
@@ -76,7 +76,8 @@ class AppView {
       // console.log(window.location.hash.slice(14));
       const id = +window.location.hash.slice(14);
       const product = Cart.getProduct(id);
-      page.render(product);
+      // console.log(product);
+      page.render(product, id);
     }
 
     if (page instanceof CartPage) {

--- a/src/modules/view/pages/pageProduct.ts
+++ b/src/modules/view/pages/pageProduct.ts
@@ -197,10 +197,27 @@ class ProductPage extends Page {
     this.container.append(product);
   }
 
-  public render(item?: IProduct): HTMLElement {
-    this.breadcrumbs(item);
-    this.renderProduct(item);
-    this.renderButtons(item);
+  private renderEmptyProduct(id: number) {
+    const emptyProdWrap = document.createElement('div');
+    emptyProdWrap.classList.add('empty_product');
+    emptyProdWrap.innerText = `Sorry. Product with id ${id} was not found`;
+
+    this.container.append(emptyProdWrap);
+  }
+
+  public render(item?: IProduct, id?: number): HTMLElement {
+    if (item) {
+      this.breadcrumbs(item);
+      this.renderProduct(item);
+      this.renderButtons(item);
+    } else {
+      if (id) {
+        this.renderEmptyProduct(id);
+      }
+    }
+    // this.breadcrumbs(item);
+    // this.renderProduct(item);
+    // this.renderButtons(item);
     return this.container;
   }
 }

--- a/src/style/_product_page.scss
+++ b/src/style/_product_page.scss
@@ -2,6 +2,13 @@
   margin: 24px 0;
   padding: 0 24px;
 
+  & .empty_product {
+    padding: 40px;
+    height: 80vh;
+    text-align: center;
+    font-weight: bold;
+  }
+
   & .item_name {
     grid-column-start: 1;
     grid-row-start: 1;


### PR DESCRIPTION
1) подправила appView для страницы товара и корзины:
- если открыть по ссылке страницу с товаром в отдельном окне, то отрисуется страница с товаром (даже если не заходить на главную)
- отрисуется пустая корзина (если зайти в корзину напрямую по ссылке, не через главную). Если есть данные в локал сторадж отрисуется полная корзина
2) добавила обработку несуществуещего id товара на product page - **есть баг (если вводить адрес без нижнего подчёркивания перед id `#product-page33`, (а мы получаем id через slice) то id распознается как `3` и откроется карточка третьего товара (если бы 33й, то такого не существует)**

**нужно проверить, работает ли такой роутинг на деплое - локально у меня работает**

вроде работает

![image](https://user-images.githubusercontent.com/99749026/210881372-afdb750a-7de8-4f04-850c-bd8a0037ec3b.png)

несуществующий id
СТАЛО:
![image](https://user-images.githubusercontent.com/99749026/210884011-5873ab43-4455-4e9b-a564-77089c7fb1c0.png)
БЫЛО:
![image](https://user-images.githubusercontent.com/99749026/210881532-a52fdd2b-5ce8-43db-b441-fac8c7235272.png)
